### PR TITLE
.integrations deprecation waring and note about installationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const app = createApp({
 Authenticate [as an installation](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-an-installation), returning a [github API client](https://github.com/mikedeboer/node-github), which can be used to call any of the [APIs supported by GitHub Apps](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-an-installation):
 
 ```js
+//Modify value according to getInstallations return(example in asApp section)
 var installationId = 99999;
 
 app.asInstallation(installationId).then(github => {
@@ -46,6 +47,6 @@ Authenticate [as an app](https://developer.github.com/apps/building-integrations
 ```js
 app.asApp().then(github => {
   console.log("Installations:")
-  github.integrations.getInstallations({}).then(console.log);
+  github.apps.getInstallations({}).then(console.log);
 });
 ```


### PR DESCRIPTION
`github.integrations` is deprecated. Also it was unclear where `installationId` was coming from.