### PR TITLE
Experiment with porting to octokit plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,43 +1,41 @@
-const jwt = require('jsonwebtoken')
-const GitHubApi = require('github')
+const jsonwebtoken = require('jsonwebtoken')
 
-module.exports = function ({id, cert, debug = false}) {
-  function asApp () {
-    const github = new GitHubApi({debug})
-    github.authenticate({type: 'integration', token: generateJwt(id, cert)})
-    // Return a promise to keep API consistent
-    return Promise.resolve(github)
+function jwt (id, pem) {
+  console.log({id, pem})
+
+  const payload = {
+    iat: Math.floor(new Date() / 1000),       // Issued at time
+    exp: Math.floor(new Date() / 1000) + 60,  // JWT expiration time
+    iss: id                                   // Integration's GitHub id
   }
 
-  // Authenticate as the given installation
-  function asInstallation (installationId) {
-    return createToken(installationId).then(res => {
-      const github = new GitHubApi({debug})
-      github.authenticate({type: 'token', token: res.data.token})
-      return github
-    })
-  }
+  // Sign with RSA SHA256
+  return jsonwebtoken.sign(payload, pem, {algorithm: 'RS256'})
+}
 
-  // https://developer.github.com/early-access/integrations/authentication/#as-an-installation
-  function createToken (installationId) {
-    return asApp().then(github => {
-      return github.apps.createInstallationToken({
-        installation_id: installationId
-      })
-    })
-  }
+module.exports = ({id, pem}) => {
+  return octokit => {
+    octokit.jwt = jwt.bind(null, id, pem)
 
-  // Internal - no need to exose this right now
-  function generateJwt (id, cert) {
-    const payload = {
-      iat: Math.floor(new Date() / 1000),       // Issued at time
-      exp: Math.floor(new Date() / 1000) + 60,  // JWT expiration time
-      iss: id                                   // Integration's GitHub id
+    // Save the original octokit authenticate method
+    const authenticate = octokit.authenticate
+
+    // Authenticate this instance as the GitHub App
+    // FIXME: this will only work for requests within the next 60 sec
+    authenticate({ type: 'app', token: octokit.jwt() })
+
+    octokit.authenticate = async (options) => {
+      if (options.type === 'installation') {
+        octokit.authenticate({ type: 'app', token: octokit.jwt() })
+
+        const { data: { token } } = await octokit.apps.createInstallationToken({
+          installation_id: options.id
+        })
+
+        return authenticate({ type: 'token', token })
+      } else {
+        return authenticate(options)
+      }
     }
-
-    // Sign with RSA SHA256
-    return jwt.sign(payload, cert, {algorithm: 'RS256'})
   }
-
-  return {asApp, asInstallation, createToken}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-app",
+  "name": "@octokit/github-app",
   "version": "3.2.0",
   "description": "NodeJS module for building GitHub Apps",
   "repository": "probot/github-app",
@@ -10,12 +10,15 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "github": "^10.1.0",
     "jsonwebtoken": "^7.3.0"
   },
   "devDependencies": {
+    "@octokit/rest": "^15.10.0",
     "eslint-plugin-import": "^2.7.0",
     "standard": "^10.0.3"
+  },
+  "peerDependencies": {
+    "@octokit/rest": "^15.0.0"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
@cirpo's feature request in https://github.com/octokit/rest.js/issues/980, as well as @gjtorikian pinging me about https://github.com/probot/github-app/pull/13 got me wondering what it would take to convert this module a plugin for  `@octokit/rest`.

From the updated README:

---

### Usage

```js
const octokit = require('@octokit/rest')()
const githubApp = require('@octokit/github-app')
const fs = require('fs')

octokit.plugin(githubApp({
  id: 1234,
  pem: fs.readFileSync('private-key.pem', 'UTF-8')
}))
```

All requests are now authenticated [as the app](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-a-github-app).

```js
octokit.apps.getInstallations({}).then(res => {
  console.log('Installations:', res)  
})
```

To authenticate [as a specific installation](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-an-installation), which can be used to call any of the [APIs supported by GitHub Apps](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-an-installation), call `authenticate` with `type: 'installation'`:

```js
octokit.authenticate({
  type: 'installation',
  id: 12345
}).then(() => {
  octokit.issues.createComment({
    owner: 'foo',
    repo: 'bar',
    number: 999,
    body: 'hello world!'
  })
})
```

> **Important!** This plugin changes the API of `octokit.authenticate` to return a `Promise`. You _must_ wait for the Promise to resolve with `await` or by calling `.then()`.

---

Here's a quick test script I wrote using this branch:

```js
const octokit = require('@octokit/rest')()
const githubApp = require('.')
const fs = require('fs')

octokit.plugin(githubApp({
  id: 11053,
  pem: fs.readFileSync('private-key.pem', 'UTF-8')
}))

async function test () {
  const { data: installations } = await octokit.apps.getInstallations({})
  console.log('Installations:', installations)

  await octokit.authenticate({ type: 'installation', id: installations[0].id })
  const { data: repositories } = await octokit.apps.getInstallationRepositories({})
  console.log('Repositories:', repositories)
}

test()
```

There's still work to do here, but I think this will work. 

 

