### PR TITLE
Authenticate with 'app' type instead of deprecated 'integration'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const GitHubApi = require('@octokit/rest')
 module.exports = function ({id, cert, debug = false}) {
   function asApp () {
     const github = new GitHubApi({debug})
-    github.authenticate({type: 'integration', token: generateJwt(id, cert)})
+    github.authenticate({type: 'app', token: generateJwt(id, cert)})
     // Return a promise to keep API consistent
     return Promise.resolve(github)
   }


### PR DESCRIPTION
This removes the deprecation warning.

I've just noticed a big overhaul coming up in another PR, hope that incremental changes are still okay.